### PR TITLE
Added path argument for generate-build-meta script

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,6 +2,8 @@
 
 const fs = require('fs');
 const uuidv4 = require('uuid/v4');
+const process = require('process');
+const minimist = require('minimist');
 
 const appVersion = uuidv4();
 
@@ -11,8 +13,11 @@ const jsonData = {
 
 const jsonContent = JSON.stringify(jsonData);
 
+const args = minimist(process.argv.slice(2));
+const filePath = args.path || './public';
+
 fs.writeFile(
-  './public/meta.json',
+  filePath + '/meta.json',
   jsonContent,
   { flag: 'w+', encoding: 'utf8' },
   err => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "dependencies": {
+    "minimist": "^1.2.0",
     "use-persisted-state": "^0.3.0",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
User will be able to set path to meta.json:
For example:
"generate-build-meta": "./node_modules/react-clear-cache/bin/cli.js --path ./build"
Default path will be './public/meta.json'