### PR TITLE
Fixed scripts section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This will generate `meta.json` file. This will have the version key with the lat
 
 ```bash
 {
-  "postbuild": "npm run generate-build-meta",
+  "prebuild": "npm run generate-build-meta",
   "generate-build-meta": "./node_modules/react-clear-cache/bin/cli.js"
 }
 ```


### PR DESCRIPTION
Changed `postbuild` to `prebuild` because `postbuild` generates the `meta.json` file after the build so it's not being copied.

Also, the example uses `prebuild` instead of `postbuild`.