### PR TITLE
Wait for cache to clear before reloading page.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,16 +32,13 @@ export const useClearCache = (props?: OwnProps) => {
   const emptyCacheStorage = async (version?: string) => {
     if ('caches' in window) {
       // Service worker cache should be cleared with caches.delete()
-      caches.keys().then(names => {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const name of names) caches.delete(name);
-      });
+      const cacheKeys = await window.caches.keys();
+      await Promise.all(cacheKeys.map(window.caches.delete));
     }
 
     // clear browser cache and reload page
-    await setVersion(version || latestVersion).then(() =>
-      window.location.reload(true)
-    );
+    await setVersion(version || latestVersion);
+    window.location.reload(true);
   };
 
   // Replace any last slash with an empty space


### PR DESCRIPTION
Cache.delete() also [returns a Promise](https://developer.mozilla.org/en-US/docs/Web/API/Cache/delete).  
Consequently the reload could be triggered before the caches are fully cleared.

This could be further optimised by including the setVersion into the Promise.all, but I opted for less change and better readibility, as the effect would likely be extremely minimal.