### PR TITLE
add catch statement - fetchMeta method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,7 +98,9 @@ export const useClearCache = (props?: OwnProps) => {
             setIsLatestVersion(true);
             setLoading(false);
           }
-        });
+        }).catch(err => {
+          console.error(err);
+        })
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Added error capture in the fetchMeta method

Reason: in case of an error in feth, the application generates an 'Uncaught (in promise)' error