### PR TITLE
Specify mkdirp version in order to solve "invalid options argument" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "minimist": "^1.2.5",
     "use-persisted-state": "^0.3.0",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "mkdirp": "0.5.6"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",


### PR DESCRIPTION
We need to specify the version of **mkdirp** to avoid incompatibilities with other libraries, for example **node-sass**


Example of error: 
```
C:\APPS\react-example\node_modules\mkdirp\lib\opts-arg.js:13
    throw new TypeError('invalid options argument')
    ^

TypeError: invalid options argument
    at optsArg (C:\APPS\react-example\node_modules\mkdirp\lib\opts-arg.js:13:11)
    at mkdirp (C:\APPS\react-example\node_modules\mkdirp\index.js:11:10)
    at writeFile (C:\APPS\react-example\node_modules\react-clear-cache\bin\cli.js:37:3)
    at Object.<anonymous> (C:\APPS\react-example\node_modules\react-clear-cache\bin\cli.js:23:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
```
![image](https://github.com/nucab/react-clear-cache/assets/45885904/d3ff1885-7e48-4dac-acf9-5891e02cf632)

@nucab 